### PR TITLE
cannot import name "MutableMapping" from collections 

### DIFF
--- a/amt.py
+++ b/amt.py
@@ -22,7 +22,7 @@ from mutagen.mp4 import MP4, MP4Cover
 
 # The following subtitle codecs are ingored if found in the file as they are
 # not supported by the mp4 container. These are mainly picture-based subtitles
-sub_codec_blacklist = ("dvdsub", "dvd_subtitle", "pgssub")
+sub_codec_blacklist = ("dvdsub", "dvd_subtitle", "pgssub", "hdmv_pgs_subtitle")
 
 def collect_stream_metadata(filename):
     """


### PR DESCRIPTION
I have tried this multiple different ways, attempted installing additional modules to see if that might help, but with no luck. Do you have any idea what is causing the error and how do i fix it.?